### PR TITLE
Fix Errors when value is null

### DIFF
--- a/structures/methods/add.js
+++ b/structures/methods/add.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;

--- a/structures/methods/add.js
+++ b/structures/methods/add.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;

--- a/structures/methods/add.js
+++ b/structures/methods/add.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;

--- a/structures/methods/auto_increment.js
+++ b/structures/methods/auto_increment.js
@@ -4,7 +4,7 @@ const errors = require('../errors/strings.js');
 
 module.exports = async function(table, number){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
-	if(number === undefined) throw new TypeError(errors.number.replace("{received}", number));
+	if(!number) throw new TypeError(errors.number.replace("{received}", number));
 	if(isNaN(number) || number < 1) throw new TypeError(errors.numberType.replace("{received}", number));
 	
 	await this.query(`ALTER TABLE ${table} AUTO_INCREMENT = ${number};`);

--- a/structures/methods/auto_increment.js
+++ b/structures/methods/auto_increment.js
@@ -4,7 +4,7 @@ const errors = require('../errors/strings.js');
 
 module.exports = async function(table, number){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
-	if(number == null) throw new TypeError(errors.number.replace("{received}", number));
+	if(number === undefined) throw new TypeError(errors.number.replace("{received}", number));
 	if(isNaN(number) || number < 1) throw new TypeError(errors.numberType.replace("{received}", number));
 	
 	await this.query(`ALTER TABLE ${table} AUTO_INCREMENT = ${number};`);

--- a/structures/methods/auto_increment.js
+++ b/structures/methods/auto_increment.js
@@ -4,7 +4,7 @@ const errors = require('../errors/strings.js');
 
 module.exports = async function(table, number){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
-	if(!number) throw new TypeError(errors.number.replace("{received}", number));
+	if(number === undefined) throw new TypeError(errors.number.replace("{received}", number));
 	if(isNaN(number) || number < 1) throw new TypeError(errors.numberType.replace("{received}", number));
 	
 	await this.query(`ALTER TABLE ${table} AUTO_INCREMENT = ${number};`);

--- a/structures/methods/base_set.js
+++ b/structures/methods/base_set.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(typeof value !== "string") throw new TypeError(errors.baseNotString);
 	
 	await this.set(table, key, Buffer.from(value, 'binary').toString('base64'));

--- a/structures/methods/base_set.js
+++ b/structures/methods/base_set.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(typeof value !== "string") throw new TypeError(errors.baseNotString);
 	
 	await this.set(table, key, Buffer.from(value, 'binary').toString('base64'));

--- a/structures/methods/base_set.js
+++ b/structures/methods/base_set.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	if(typeof value !== "string") throw new TypeError(errors.baseNotString);
 	
 	await this.set(table, key, Buffer.from(value, 'binary').toString('base64'));

--- a/structures/methods/includes.js
+++ b/structures/methods/includes.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key) || [];
 	if(!Array.isArray(data)) throw new TypeError(errors.array.replace("{key}", key));

--- a/structures/methods/includes.js
+++ b/structures/methods/includes.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key) || [];
 	if(!Array.isArray(data)) throw new TypeError(errors.array.replace("{key}", key));

--- a/structures/methods/includes.js
+++ b/structures/methods/includes.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key) || [];
 	if(!Array.isArray(data)) throw new TypeError(errors.array.replace("{key}", key));

--- a/structures/methods/pull.js
+++ b/structures/methods/pull.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value, option){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key);
 	if(!data) throw new TypeError(errors.dataNotFound.replace("{key}", key));

--- a/structures/methods/pull.js
+++ b/structures/methods/pull.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value, option){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key);
 	if(!data) throw new TypeError(errors.dataNotFound.replace("{key}", key));

--- a/structures/methods/pull.js
+++ b/structures/methods/pull.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value, option){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let data = await this.get(table, key);
 	if(!data) throw new TypeError(errors.dataNotFound.replace("{key}", key));

--- a/structures/methods/push.js
+++ b/structures/methods/push.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let res;
 	let tables = await this.tables();

--- a/structures/methods/push.js
+++ b/structures/methods/push.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let res;
 	let tables = await this.tables();

--- a/structures/methods/push.js
+++ b/structures/methods/push.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	let res;
 	let tables = await this.tables();

--- a/structures/methods/set.js
+++ b/structures/methods/set.js
@@ -6,7 +6,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	await this.create(table);
 	

--- a/structures/methods/set.js
+++ b/structures/methods/set.js
@@ -6,7 +6,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	
 	await this.create(table);
 	

--- a/structures/methods/set.js
+++ b/structures/methods/set.js
@@ -6,7 +6,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	
 	await this.create(table);
 	

--- a/structures/methods/sub.js
+++ b/structures/methods/sub.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
+	if(!value) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;

--- a/structures/methods/sub.js
+++ b/structures/methods/sub.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(value == null) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;

--- a/structures/methods/sub.js
+++ b/structures/methods/sub.js
@@ -5,7 +5,7 @@ const errors = require('../errors/strings.js');
 module.exports = async function(table, key, value){
 	if(!table) throw new TypeError(errors.table.replace("{received}", table));
 	if(!key) throw new TypeError(errors.key.replace("{received}", key));
-	if(!value) throw new TypeError(errors.value.replace("{received}", value));
+	if(value === undefined) throw new TypeError(errors.value.replace("{received}", value));
 	if(isNaN(value) || value <= 0) throw new TypeError(errors.numberType.replace("{received}", value));
 	
 	let res;


### PR DESCRIPTION
احيانا  ممكن المستخدم يحط null 
ب value


السبب هو انه ممكن يكون عنده object ب value مثلا
```js
{
   avatar: "AVATAR_CODE",
   username: "USERNAME"
}
```

بالطبيعي رح تسجل الداتا هيك
```js
const user_obj ={
   avatar: "AVATAR_CODE",
   username: "USERNAME"
}

await db.set("users", "USER_ID", user_obj)
```
ممكن المتسخدم يشيل ال avatar
وقتها رح يسجل هيك
```js
await db.set("users", "USER_ID.avatar", null)
```
يعني ماله افاتار


المشكلة انه بالمكتبة لما اسجل null ما يقبل 

المفروض ما يقبل undefined
لأن كمنطق
```js
function my_function(param) {
   return param
} 
my_function() // undefined
my_function("my_param") // "my_param"
```

الحل انه غيرت من 
```js
if (value == null) throw new TypeError(errors.value.replace("{received}", value))
```
الى
```js
if (value === undefined) throw new TypeError(errors.value.replace("{received}", value))
```
عشان يكون أصح كمنطق وأقدر أسجل null 
لأن بالعادة ما أـوقع أحد يسجل undefined